### PR TITLE
wrong function name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ if (Meteor.isServer) {
 	
 if (Meteor.isClient) {
   // available immediately
-  var myData = Injected.getObj('myData');
+  var myData = Injected.obj('myData');
 }
 ```
 


### PR DESCRIPTION
I followed the readme and found that `getObj` does not exist. I thought i fix that quickly ;)
