### PR TITLE
Make `Inject` available in the entire app

### DIFF
--- a/inject-server.js
+++ b/inject-server.js
@@ -1,4 +1,4 @@
-Inject = {
+Inject = this.Inject = {
 
   // stores in a script type=application/ejson tag, accessed with Injected.obj('id')
   obj: function(id, data, res) {


### PR DESCRIPTION
For cases when creating a separate smart package is an overkill, eg. when you just want to inject a single polyfill script that'll run before all packages.