### PR TITLE
Server outputs id not name attributes for meta

### DIFF
--- a/lib/inject-client.js
+++ b/lib/inject-client.js
@@ -15,7 +15,7 @@ Injected = {
 	parseMetas: function() {
 		var metaEls = document.getElementsByTagName('meta');
 		for (var i=0; i < metaEls.length; i++)
-			this.metas[ metaEls[i].getAttribute('name') ]
+			this.metas[ metaEls[i].getAttribute('id') ]
 				= metaEls[i].getAttribute('content');
 	},
 	metas: {}


### PR DESCRIPTION
The Injected.meta currently does not work because the server side outputs meta tags with id and the client is looking for element name.